### PR TITLE
Fix storage cost of 1MB

### DIFF
--- a/src/routes/(examples)/02-variables/content.md
+++ b/src/routes/(examples)/02-variables/content.md
@@ -2,7 +2,7 @@
 
 The most important variables are those that are persisted in state and retain their value between contract executions. They must be defined in the scope of the contract like `contractVar1`.
 
-Persisting data in state costs gas. The contract must pay rent periodically from its balance. State storage is expensive, about [4 TON per MB per year](https://ton.org/docs/develop/smart-contracts/fees#how-to-calculate-fees). If the contract runs out of balance, the data will be deleted. If you need to store large amounts of data, like images, a service like [TON Storage](https://ton.org/docs/participate/ton-storage/storage-faq) would be more suitable.
+Persisting data in state costs gas. The contract must pay rent periodically from its balance. State storage is expensive, about [6 TON per MB per year](https://ton.org/docs/develop/smart-contracts/fees#how-to-calculate-fees). If the contract runs out of balance, the data will be deleted. If you need to store large amounts of data, like images, a service like [TON Storage](https://ton.org/docs/participate/ton-storage/storage-faq) would be more suitable.
 
 Persistent state variables can only change in *receivers* by sending messages as transactions. Sending these transactions will cost gas to users.
 


### PR DESCRIPTION
Previously the calculator on the referenced page had a bug that was showing 4 TON cost for storage of 1MB for a year. Now it is fixed and shows 6 TON.