### PR TITLE
fix: condition in withdraw receiver in 04-decimal-point.html

### DIFF
--- a/docs/04-decimal-point.html
+++ b/docs/04-decimal-point.html
@@ -104,7 +104,7 @@ contract Interest with Deployable {
     }
 
     receive(msg: Withdraw) {
-        require(msg.amount >= self.depositAmount, "Cannot withdraw more than deposit");
+        require(msg.amount <= self.depositAmount, "Cannot withdraw more than deposit");
         self.depositAmount = self.depositAmount - msg.amount;
         let durationSeconds: Int = now() - self.depositTime;
         let earned: Int = msg.amount * durationSeconds * self.interestPercent / SecondsPerYear / 100000;


### PR DESCRIPTION
By condition withdraw amount must be smaller than or equal to deposit amount. 
[require function documentation](https://docs.tact-lang.org/language/ref/common#require)