### PR TITLE
fix: example 04-arrays with 1.4.2 Tact compiler

### DIFF
--- a/docs/04-arrays.html
+++ b/docs/04-arrays.html
@@ -124,7 +124,7 @@ contract Arrays with Deployable {
         return self.arrLength;
     }
 
-    get fun map(): map<Int, Int> {
+    get fun mapping(): map<Int, Int> {
         return self.arr;
     }
 }</pre></div></div></div></div>

--- a/src/routes/(examples)/04-arrays/+page.svelte
+++ b/src/routes/(examples)/04-arrays/+page.svelte
@@ -37,7 +37,7 @@
       length: async () => {
         return await contract.getLength();
       },
-      map: async () => {
+      mapping: async () => {
         return await contract.getMap();
       },
     },

--- a/src/routes/(examples)/04-arrays/contract.tact
+++ b/src/routes/(examples)/04-arrays/contract.tact
@@ -44,7 +44,7 @@ contract Arrays with Deployable {
         return self.arrLength;
     }
 
-    get fun map(): map<Int, Int> {
+    get fun mapping(): map<Int, Int> {
         return self.arr;
     }
 }


### PR DESCRIPTION
"map" became a reserved keyword

Fixes #43
